### PR TITLE
Load JuiceVlk.dll for vkGetInstanceProcAddress using user DLL search …

### DIFF
--- a/src/vulkan/vulkan_loader.cpp
+++ b/src/vulkan/vulkan_loader.cpp
@@ -1,6 +1,6 @@
 #include "vulkan_loader.h"
-
 #include <mutex>
+#include <assert.h>
 
 namespace dxvk::vk {
 
@@ -9,8 +9,10 @@ namespace dxvk::vk {
 
     static std::once_flag loaded;
     std::call_once(loaded, []() {
-      HMODULE mod = LoadLibraryA("JuiceVlk.dll");
-      GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)GetProcAddress(mod, "vkGetInstanceProcAddr");
+      HMODULE juiceVlk = LoadLibraryExA("JuiceVlk.dll", NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+      assert(juiceVlk);
+      GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)GetProcAddress(juiceVlk, "vkGetInstanceProcAddr");
+      assert(GetInstanceProcAddr);
     });
 
     if(GetInstanceProcAddr != nullptr)


### PR DESCRIPTION
…dirs.

The directory to load JuiceVlk.dll from is set by `AddDllDirectory()` in `JuiceShim{32,64}.dll` but this search path is only used in calls to `LoadLibraryEx()` that pass the `LOAD_LIBRARY_SEARCH_USER_DIRS` flag.  The `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` flag that is used also searches the system directory for `dbghelp.dll` which is loaded by `JuiceVlk.dll`.