### PR TITLE
Resolve crash in The Settlers submitting (possibly incorrectly) an SRV to ClearUnorderedAccessViewUint 

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -386,10 +386,17 @@ namespace dxvk {
     const UINT                              Values[4]) {
     D3D10DeviceLock lock = LockContext();
 
-    auto uav = static_cast<D3D11UnorderedAccessView*>(pUnorderedAccessView);
-
-    if (!uav)
+    if (!pUnorderedAccessView)
       return;
+
+    Com<ID3D11UnorderedAccessView> qiUav;
+
+    if (FAILED(pUnorderedAccessView->QueryInterface(IID_PPV_ARGS(&qiUav))))
+    {
+      return;
+    }
+
+    auto uav = static_cast<D3D11UnorderedAccessView*>(qiUav.ptr());
 
     // Gather UAV format info. We'll use this to determine
     // whether we need to create a temporary view or not.


### PR DESCRIPTION
The Settlers: New Allies, crashes on launch due to the fact that it tries to submit an SRV to clearance via ClearUnorderedAccessViewUint. 

The native behavior is to ignore the errant resource type (see attached repro of the behavior) but dxvk, due to a static cast, crashes when it references the mis-cast object. This change does a QI and confirms the correct object before use, returning immediately if it is not.

[D3D11SrvClearTest.cpp](https://github.com/Juice-Labs/dxvk/files/13553108/D3D11SrvClearTest.txt)
